### PR TITLE
Add pytest suite for app

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,13 +3,10 @@ import streamlit as st
 import requests
 import os
 
-# Ensure the TMDB API key is available before continuing
-TMDB_API_KEY = os.getenv("TMDB_API_KEY")
-if not TMDB_API_KEY:
-    st.error(
-        "TMDB_API_KEY environment variable not set. Please configure it to fetch movie posters."
-    )
-    st.stop()
+
+# Global variables populated when running the app
+movies = None
+similarity = None
 
 
 def fetch_poster(movie_id):
@@ -54,43 +51,59 @@ def recommend(movie):
     return recommended_movie_names, recommended_movie_posters
 
 
-st.header('Movie Recommender System')
+def main():
+    """Run the Streamlit app."""
+    # Ensure the TMDB API key is available before continuing
+    tmdb_api_key = os.getenv("TMDB_API_KEY")
+    if not tmdb_api_key:
+        st.error(
+            "TMDB_API_KEY environment variable not set. Please configure it to fetch movie posters."
+        )
+        st.stop()
 
-model_dir = 'model'
-movie_file = os.path.join(model_dir, 'movie_list.pkl')
-sim_file = os.path.join(model_dir, 'similarity.pkl')
+    global movies, similarity
 
-if os.path.exists(movie_file) and os.path.exists(sim_file):
-    movies = pickle.load(open(movie_file, 'rb'))
-    similarity = pickle.load(open(sim_file, 'rb'))
-else:
-    st.error(
-        'Required model files not found. Run the notebook to generate them.'
+    st.header('Movie Recommender System')
+
+    model_dir = 'model'
+    movie_file = os.path.join(model_dir, 'movie_list.pkl')
+    sim_file = os.path.join(model_dir, 'similarity.pkl')
+
+    if os.path.exists(movie_file) and os.path.exists(sim_file):
+        movies = pickle.load(open(movie_file, 'rb'))
+        similarity = pickle.load(open(sim_file, 'rb'))
+    else:
+        st.error(
+            'Required model files not found. Run the notebook to generate them.'
+        )
+        st.stop()
+
+    movie_list = movies['title'].values
+    selected_movie = st.selectbox(
+        "Type or select a movie from the dropdown",
+        movie_list
     )
-    st.stop()
 
-movie_list = movies['title'].values
-selected_movie = st.selectbox(
-    "Type or select a movie from the dropdown",
-    movie_list
-)
+    if st.button('Show Recommendation'):
+        recommended_movie_names, recommended_movie_posters = recommend(selected_movie)
+        col1, col2, col3, col4, col5 = st.columns(5)
+        with col1:
+            st.text(recommended_movie_names[0])
+            st.image(recommended_movie_posters[0])
+        with col2:
+            st.text(recommended_movie_names[1])
+            st.image(recommended_movie_posters[1])
 
-if st.button('Show Recommendation'):
-    recommended_movie_names,recommended_movie_posters = recommend(selected_movie)
-    col1, col2, col3, col4, col5 = st.columns(5)
-    with col1:
-        st.text(recommended_movie_names[0])
-        st.image(recommended_movie_posters[0])
-    with col2:
-        st.text(recommended_movie_names[1])
-        st.image(recommended_movie_posters[1])
+        with col3:
+            st.text(recommended_movie_names[2])
+            st.image(recommended_movie_posters[2])
+        with col4:
+            st.text(recommended_movie_names[3])
+            st.image(recommended_movie_posters[3])
+        with col5:
+            st.text(recommended_movie_names[4])
+            st.image(recommended_movie_posters[4])
 
-    with col3:
-        st.text(recommended_movie_names[2])
-        st.image(recommended_movie_posters[2])
-    with col4:
-        st.text(recommended_movie_names[3])
-        st.image(recommended_movie_posters[3])
-    with col5:
-        st.text(recommended_movie_names[4])
-        st.image(recommended_movie_posters[4])
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,109 @@
+import sys
+import types
+import importlib
+import builtins
+import os
+
+import pytest
+
+
+def load_app(monkeypatch):
+    """Import the app module with stubbed dependencies."""
+    streamlit_stub = types.SimpleNamespace(
+        error=lambda *a, **k: None,
+        stop=lambda: None,
+        header=lambda *a, **k: None,
+        selectbox=lambda *a, **k: None,
+        button=lambda *a, **k: False,
+        columns=lambda n: [types.SimpleNamespace(text=lambda *a, **k: None,
+                                                image=lambda *a, **k: None) for _ in range(n)],
+    )
+    requests_stub = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "streamlit", streamlit_stub)
+    monkeypatch.setitem(sys.modules, "requests", requests_stub)
+    # Ensure repository root is on sys.path for imports
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    monkeypatch.syspath_prepend(repo_root)
+    if "app" in sys.modules:
+        del sys.modules["app"]
+    return importlib.import_module("app")
+
+
+class DummyMovies:
+    class TitleList(list):
+        def __eq__(self, other):
+            return [x == other for x in self]
+
+    def __init__(self, rows, indexes=None):
+        self.rows = list(rows)
+        self._indexes = list(range(len(rows))) if indexes is None else indexes
+
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            if key == "title":
+                return DummyMovies.TitleList([row["title"] for row in self.rows])
+            raise KeyError(key)
+        elif isinstance(key, list):
+            selected_rows = [row for row, flag in zip(self.rows, key) if flag]
+            selected_idx = [idx for idx, flag in zip(self._indexes, key) if flag]
+            return DummyMovies(selected_rows, selected_idx)
+        else:
+            raise TypeError
+
+    @property
+    def index(self):
+        return self._indexes
+
+    class _ILoc:
+        def __init__(self, outer):
+            self.outer = outer
+        def __getitem__(self, idx):
+            row = self.outer.rows[idx]
+            return types.SimpleNamespace(**row)
+
+    @property
+    def iloc(self):
+        return DummyMovies._ILoc(self)
+
+
+def test_fetch_poster(monkeypatch):
+    app = load_app(monkeypatch)
+
+    class MockResponse:
+        def json(self):
+            return {"poster_path": "test.jpg"}
+        def raise_for_status(self):
+            pass
+
+    def mock_get(url):
+        return MockResponse()
+
+    monkeypatch.setattr(app.requests, "get", mock_get, raising=False)
+    monkeypatch.setenv("TMDB_API_KEY", "dummy")
+
+    assert (
+        app.fetch_poster(123)
+        == "https://image.tmdb.org/t/p/w500/test.jpg"
+    )
+
+
+def test_recommend(monkeypatch):
+    app = load_app(monkeypatch)
+    rows = [
+        {"movie_id": 1, "title": "A"},
+        {"movie_id": 2, "title": "B"},
+        {"movie_id": 3, "title": "C"},
+    ]
+    movies = DummyMovies(rows)
+    similarity = [
+        [1, 0.1, 0.9],
+        [0.1, 1, 0.2],
+        [0.9, 0.2, 1],
+    ]
+    monkeypatch.setattr(app, "movies", movies)
+    monkeypatch.setattr(app, "similarity", similarity)
+    monkeypatch.setattr(app, "fetch_poster", lambda mid: f"url_{mid}")
+
+    names, posters = app.recommend("A")
+    assert names == ["C", "B"]
+    assert posters == ["url_3", "url_2"]


### PR DESCRIPTION
## Summary
- refactor `app.py` so that UI is only executed when run as a script
- add small test suite with API call mocking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de2e208988321a2efd8297d7541b0