### PR TITLE
Improve CI artifact creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,12 @@ jobs:
         run: pytest
       - name: Build Streamlit artifact
         run: |
-          echo 'streamlit: placeholder' > streamlit_info.txt
+          mkdir -p build
+          cp app.py requirements.txt build/
+          if [ -d model ]; then cp -r model build/; fi
+          tar -czf streamlit_app.tar.gz -C build .
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: streamlit-app
-          path: streamlit_info.txt
+          path: streamlit_app.tar.gz


### PR DESCRIPTION
## Summary
- replace placeholder artifact step with a real build step
- package app.py, requirements and model directory
- upload the resulting tarball

## Testing
- `pytest -q`
- ❌ `pip install flake8 pytest` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685dfdbb1a6c8321b87149f2b21c49ab