### PR TITLE
Add Pytest cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ model/*.pkl
 
 # Streamlit configuration
 .streamlit/
+
+# Test artifacts
+.pytest_cache/


### PR DESCRIPTION
## Summary
- ensure `.streamlit/` is ignored
- add `.pytest_cache/` to ignore test artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e137c5f388321912862900f8224e0