### PR TITLE
Fix linter failures in tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,7 +9,6 @@ import pickle
 
 import pytest
 
-
 def load_app(monkeypatch, open_func=None, pickle_loader=None):
     """Import the app module with stubbed dependencies."""
     streamlit_stub = types.SimpleNamespace(
@@ -49,7 +48,6 @@ def load_app(monkeypatch, open_func=None, pickle_loader=None):
     if "app" in sys.modules:
         del sys.modules["app"]
     return importlib.import_module("app")
-
 
 class DummyMovies:
     class TitleList(list):
@@ -96,8 +94,6 @@ class Timeout(Exception):
 class RequestException(Exception):
     pass
 
-
-
 def test_fetch_poster(monkeypatch):
     app = load_app(monkeypatch)
 
@@ -118,7 +114,6 @@ def test_fetch_poster(monkeypatch):
         app.fetch_poster(123)
         == "https://image.tmdb.org/t/p/w500/test.jpg"
     )
-
 
 def test_recommend(monkeypatch):
     app = load_app(monkeypatch)
@@ -142,7 +137,6 @@ def test_recommend(monkeypatch):
     assert posters == ["url_3", "url_2"]
 
 
-
 def test_files_loaded_with_context_manager(monkeypatch):
     entered = []
     exited = []
@@ -164,8 +158,6 @@ def test_files_loaded_with_context_manager(monkeypatch):
     assert len(exited) == 2
 
 
-
-
 def test_get_api_key_without_env(monkeypatch):
     app = load_app(monkeypatch)
     errors = []
@@ -178,7 +170,6 @@ def test_get_api_key_without_env(monkeypatch):
     assert app.get_api_key() is None
     assert stopped == [True]
     assert errors and "TMDB_API_KEY not set" in errors[0]
-
 
 def test_recommend_movie_not_found(monkeypatch):
     app = load_app(monkeypatch)
@@ -194,7 +185,6 @@ def test_recommend_movie_not_found(monkeypatch):
     assert posters == []
     assert any("not found" in m for m in msgs)
 
-
 @pytest.mark.parametrize(
     "exc, expected",
     [
@@ -209,7 +199,15 @@ def test_fetch_poster_errors(monkeypatch, exc, expected):
         raise exc
 
     monkeypatch.setattr(app.requests, "get", raise_exc, raising=False)
-    monkeypatch.setattr(app.requests, "exceptions", types.SimpleNamespace(Timeout=Timeout, RequestException=RequestException), raising=False)
+    monkeypatch.setattr(
+        app.requests,
+        "exceptions",
+        types.SimpleNamespace(
+            Timeout=Timeout,
+            RequestException=RequestException
+        ),
+        raising=False
+    )
     monkeypatch.setenv("TMDB_API_KEY", "dummy")
     errors = []
     monkeypatch.setattr(app.st, "error", lambda msg: errors.append(msg))
@@ -217,4 +215,3 @@ def test_fetch_poster_errors(monkeypatch, exc, expected):
     result = app.fetch_poster(123)
     assert result == "https://via.placeholder.com/200x300?text=No+Image"
     assert expected in errors[0]
-


### PR DESCRIPTION
## Summary
- fix blank lines and long line in `tests/test_app.py`

## Testing
- `pytest -q`
- `python -m flake8 tests/test_app.py` *(fails: No module named flake8)*

------
https://chatgpt.com/codex/tasks/task_e_685e03caafd88321a1bae2fa024b0414